### PR TITLE
Ability to Add Profile Pictures Not Saved Across App Launches

### DIFF
--- a/WestBlueGolf/WestBlueGolf.xcodeproj/project.pbxproj
+++ b/WestBlueGolf/WestBlueGolf.xcodeproj/project.pbxproj
@@ -143,6 +143,7 @@
 		A5F477141890769400AB3529 /* WestBlueGolfTests.m in Sources */ = {isa = PBXBuildFile; fileRef = A5F477131890769400AB3529 /* WestBlueGolfTests.m */; };
 		A5F4771E18907E5E00AB3529 /* CoreData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A5F4771D18907E5E00AB3529 /* CoreData.framework */; };
 		A5F4772918907F5000AB3529 /* WestBlueGolf.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = A5F4772718907F5000AB3529 /* WestBlueGolf.xcdatamodeld */; };
+		D2C274AD18DB56F500CB1B93 /* ProfilePictureCropperViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = D2C274AC18DB56F500CB1B93 /* ProfilePictureCropperViewController.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -359,6 +360,8 @@
 		A5F477131890769400AB3529 /* WestBlueGolfTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = WestBlueGolfTests.m; sourceTree = "<group>"; };
 		A5F4771D18907E5E00AB3529 /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = System/Library/Frameworks/CoreData.framework; sourceTree = SDKROOT; };
 		A5F4772818907F5000AB3529 /* WestBlueGolf.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = WestBlueGolf.xcdatamodel; sourceTree = "<group>"; };
+		D2C274AB18DB56F500CB1B93 /* ProfilePictureCropperViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ProfilePictureCropperViewController.h; sourceTree = "<group>"; };
+		D2C274AC18DB56F500CB1B93 /* ProfilePictureCropperViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ProfilePictureCropperViewController.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -814,6 +817,8 @@
 				48B221B118B034B400F2DD99 /* WBProfileTableViewController.m */,
 				48B221B718B1EB2000F2DD99 /* WBResultTableViewCell.h */,
 				48B221B818B1EB2000F2DD99 /* WBResultTableViewCell.m */,
+				D2C274AB18DB56F500CB1B93 /* ProfilePictureCropperViewController.h */,
+				D2C274AC18DB56F500CB1B93 /* ProfilePictureCropperViewController.m */,
 			);
 			name = PlayerProfile;
 			sourceTree = "<group>";
@@ -1077,6 +1082,7 @@
 				A5F476F31890769400AB3529 /* WBAppDelegate.m in Sources */,
 				A50E163E18972418008933A5 /* WBTeamMatchup.m in Sources */,
 				48B221B218B034B400F2DD99 /* WBProfileTableViewController.m in Sources */,
+				D2C274AD18DB56F500CB1B93 /* ProfilePictureCropperViewController.m in Sources */,
 				A53498ED18D2095600D52D84 /* WBYearSelectionDataSource.m in Sources */,
 				A50E163918972418008933A5 /* WBMatch.m in Sources */,
 				A56F21A918CE0C0900BF5CEE /* WBLeaderBoardManager.m in Sources */,

--- a/WestBlueGolf/WestBlueGolf/Base.lproj/Main_iPhone.storyboard
+++ b/WestBlueGolf/WestBlueGolf/Base.lproj/Main_iPhone.storyboard
@@ -538,9 +538,13 @@
                             <rect key="frame" x="0.0" y="64" width="320" height="124"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <subviews>
-                                <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" image="Taco" translatesAutoresizingMaskIntoConstraints="NO" id="LQ7-7W-INa">
+                                <imageView multipleTouchEnabled="YES" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" image="Taco" translatesAutoresizingMaskIntoConstraints="NO" id="LQ7-7W-INa">
                                     <rect key="frame" x="0.0" y="0.0" width="124" height="124"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                    <gestureRecognizers/>
+                                    <connections>
+                                        <outletCollection property="gestureRecognizers" destination="WFZ-2G-8yK" appends="YES" id="tP7-kt-aX1"/>
+                                    </connections>
                                 </imageView>
                                 <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="rt7-q2-nbu">
                                     <rect key="frame" x="128" y="0.0" width="60" height="60"/>
@@ -725,12 +729,81 @@
                         <outlet property="improvedLabel" destination="Geq-Ix-m23" id="s5w-Ua-NvM"/>
                         <outlet property="lowNetLabel" destination="M8s-mX-psv" id="Clz-EC-6Yv"/>
                         <outlet property="lowRoundLabel" destination="EwS-CX-l0q" id="cjp-AU-yJe"/>
+                        <outlet property="profileImageView" destination="LQ7-7W-INa" id="Ojg-2t-WUn"/>
                         <outlet property="winLossLabel" destination="FAp-cA-cN8" id="TRG-Md-VAd"/>
+                        <segue destination="x9x-MK-bCc" kind="modal" identifier="ProfilePictureCropperSegue" id="73b-uE-vJb"/>
                     </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="8xV-Ny-g7J" userLabel="First Responder" sceneMemberID="firstResponder"/>
+                <tapGestureRecognizer id="WFZ-2G-8yK">
+                    <connections>
+                        <action selector="tappedProfileImage:" destination="t0G-8d-uu9" id="hzC-Sx-aIQ"/>
+                    </connections>
+                </tapGestureRecognizer>
             </objects>
             <point key="canvasLocation" x="1055" y="-857"/>
+        </scene>
+        <!--Profile Picture Cropper View Controller-->
+        <scene sceneID="dWo-kW-6yL">
+            <objects>
+                <viewController id="x9x-MK-bCc" customClass="ProfilePictureCropperViewController" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="GrD-Vk-1TE"/>
+                        <viewControllerLayoutGuide type="bottom" id="Wso-hu-MNM"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="ORM-Uh-TD1">
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                        <subviews>
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="9sH-KF-idq">
+                                <rect key="frame" x="-20" y="-20" width="360" height="608"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <subviews>
+                                    <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="xok-hV-mzB">
+                                        <rect key="frame" x="20" y="20" width="320" height="568"/>
+                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                    </imageView>
+                                </subviews>
+                            </scrollView>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="e7v-zL-JoW">
+                                <rect key="frame" x="20" y="20" width="80" height="42"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" type="boldSystem" pointSize="25"/>
+                                <state key="normal" title="Cancel">
+                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                </state>
+                                <connections>
+                                    <action selector="cancelCrop:" destination="x9x-MK-bCc" eventType="touchUpInside" id="SmX-g8-fnc"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3qz-77-0O7">
+                                <rect key="frame" x="243" y="20" width="57" height="42"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" type="boldSystem" pointSize="25"/>
+                                <state key="normal" title="Crop">
+                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                </state>
+                                <connections>
+                                    <action selector="croppedImage:" destination="x9x-MK-bCc" eventType="touchUpInside" id="CXx-qn-sbs"/>
+                                </connections>
+                            </button>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstItem="3qz-77-0O7" firstAttribute="top" secondItem="GrD-Vk-1TE" secondAttribute="bottom" id="AAe-fs-psV"/>
+                            <constraint firstItem="e7v-zL-JoW" firstAttribute="leading" secondItem="ORM-Uh-TD1" secondAttribute="leading" constant="20" id="F51-uh-bLo"/>
+                            <constraint firstAttribute="trailing" secondItem="3qz-77-0O7" secondAttribute="trailing" constant="20" id="eWs-dM-zQO"/>
+                            <constraint firstItem="e7v-zL-JoW" firstAttribute="top" secondItem="GrD-Vk-1TE" secondAttribute="bottom" id="yzF-sd-DsF"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="imageView" destination="xok-hV-mzB" id="v9k-Ih-H7D"/>
+                        <outlet property="scrollView" destination="9sH-KF-idq" id="Jca-KX-gi0"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="sgR-QJ-dG3" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1521" y="-857"/>
         </scene>
         <!--Team Profile Table View Controller - Michael-->
         <scene sceneID="6CG-QI-M4d">

--- a/WestBlueGolf/WestBlueGolf/ProfilePictureCropperViewController.h
+++ b/WestBlueGolf/WestBlueGolf/ProfilePictureCropperViewController.h
@@ -1,0 +1,26 @@
+//
+//  ProfilePictureCropperViewController.h
+//  ProfilePicker
+//
+//  Created by Adam Ahrens on 3/12/14.
+//  Copyright (c) 2014 Adam Ahrens. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@class ProfilePictureCropperViewController;
+
+@protocol ProfilePictureCropperViewControllerDelegate <NSObject>
+
+- (void)profilePictureCropperViewController:(ProfilePictureCropperViewController *)controller croppedImage:(UIImage *)croppedImage;
+
+@end
+
+@interface ProfilePictureCropperViewController : UIViewController
+
+@property (strong, nonatomic) UIImage *imageToCrop;
+@property (weak, nonatomic) id <ProfilePictureCropperViewControllerDelegate> delegate;
+@property (assign, nonatomic) int radius;
+@property (strong, nonatomic) NSString *playerName;
+
+@end

--- a/WestBlueGolf/WestBlueGolf/ProfilePictureCropperViewController.m
+++ b/WestBlueGolf/WestBlueGolf/ProfilePictureCropperViewController.m
@@ -1,0 +1,117 @@
+//
+//  ProfilePictureCropperViewController.m
+//  ProfilePicker
+//
+//  Created by Adam Ahrens on 3/12/14.
+//  Copyright (c) 2014 Adam Ahrens. All rights reserved.
+//
+
+#import "ProfilePictureCropperViewController.h"
+
+@interface ProfilePictureCropperViewController () <UIScrollViewDelegate>
+
+@property (weak, nonatomic) IBOutlet UIScrollView *scrollView;
+@property (weak, nonatomic) IBOutlet UIImageView *imageView;
+
+@property (nonatomic) CGRect circleFrame;
+@property (nonatomic) CGFloat circleRadius;
+@property (strong, nonatomic) CAShapeLayer *fillLayer;
+
+@property (assign) float xCoord;
+@property (assign) float yCoord;
+
+@end
+
+@implementation ProfilePictureCropperViewController
+
+- (void)viewDidLoad
+{
+	[super viewDidLoad];
+	
+	self.imageView.image = self.imageToCrop;
+	self.scrollView.minimumZoomScale = 0.45;
+	self.scrollView.maximumZoomScale = 1.5;
+	self.scrollView.delegate = self;
+	
+	// Add a transparent layer with a cutout hole
+	UIBezierPath *path = [UIBezierPath bezierPathWithRect:self.view.bounds];
+	self.xCoord = self.view.bounds.size.width / 2.0;
+	self.yCoord = self.view.bounds.size.height / 2.0;
+	self.xCoord -= self.radius;
+	self.yCoord -= self.radius;
+	
+	self.circleFrame = CGRectMake(self.xCoord, self.yCoord, self.radius * 2, self.radius * 2);
+	
+	UIBezierPath *circle = [UIBezierPath bezierPathWithRoundedRect:self.circleFrame cornerRadius:self.radius];
+	[path appendPath:circle];
+	[path setUsesEvenOddFillRule:YES];
+	
+	self.circleRadius = self.radius;
+	
+	self.fillLayer = [CAShapeLayer layer];
+	self.fillLayer.path = path.CGPath;
+	self.fillLayer.fillRule = kCAFillRuleEvenOdd;
+	self.fillLayer.fillColor = [UIColor blackColor].CGColor;
+	self.fillLayer.opacity = 0.75;
+	[self.view.layer addSublayer:self.fillLayer];
+}
+
+- (void)viewWillAppear:(BOOL)animated
+{
+	[super viewWillAppear:animated];
+	self.scrollView.contentSize = self.imageToCrop.size;
+	self.imageView.frame = CGRectMake(0, 0, self.imageToCrop.size.width, self.imageToCrop.size.height);
+}
+
+- (IBAction)croppedImage:(id)sender {
+	//NSString *documentsPath = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES)[0];
+    //NSString *path = [documentsPath stringByAppendingPathComponent:[NSString stringWithFormat:@"%@-profile-image.png", self.playerName]];
+	
+	// Remove the fill layer
+	[self.fillLayer removeFromSuperlayer];
+	
+	//Clipping the Image
+	UIGraphicsBeginImageContextWithOptions(self.view.bounds.size, YES, 0.0);
+	[self.view drawViewHierarchyInRect:self.view.frame afterScreenUpdates:YES];
+	
+	UIImage *renderedImage = UIGraphicsGetImageFromCurrentImageContext();
+	UIGraphicsEndImageContext();
+	
+	// Add the fill layer back
+	[self.view.layer addSublayer:self.fillLayer];
+	CGFloat scale = renderedImage.scale;
+	CGRect frame = CGRectMake(self.circleFrame.origin.x * scale, self.circleFrame.origin.y * scale , 100 * scale, 100 * scale);
+	CGImageRef imageRef = CGImageCreateWithImageInRect(renderedImage.CGImage, frame);
+    UIImage *croppedImage = [UIImage imageWithCGImage:imageRef];
+	
+    // save the image
+    //NSData *data = UIImagePNGRepresentation(croppedImage);
+    //[data writeToFile:path atomically:YES];
+	
+	// Pass to the delegate
+	[self.delegate profilePictureCropperViewController:self croppedImage:croppedImage];
+}
+
+- (IBAction)cancelCrop:(id)sender {
+	[self.delegate profilePictureCropperViewController:self croppedImage:nil];
+}
+
+#pragma mark - UIScrollViewDelegate
+
+- (UIView *)viewForZoomingInScrollView:(UIScrollView *)scrollView {
+	return self.imageView;
+}
+
+- (void)scrollViewDidZoom:(UIScrollView *)scrollView
+{
+	CGFloat zoomScale = scrollView.zoomScale;
+	if (zoomScale < 1.0) {
+		CGFloat inset = 120 / zoomScale;
+		inset = floorf(inset);
+		self.scrollView.contentInset = UIEdgeInsetsMake(inset, inset, inset, inset);
+	} else {
+		self.scrollView.contentInset = UIEdgeInsetsMake(0, 0, 0, 0);
+	}
+}
+
+@end


### PR DESCRIPTION
Added the ability to select profile pictures from photo library or
camera. Images aren’t persisted between app launches. Need to determine
what to do with cropped image.
